### PR TITLE
[test] TextField 유효성 검증 로직에 대한 Boolean 기반 단위 테스트 추가

### DIFF
--- a/TVING_Clone/TVING_Clone.xcodeproj/project.pbxproj
+++ b/TVING_Clone/TVING_Clone.xcodeproj/project.pbxproj
@@ -38,6 +38,16 @@
 		E56DC4992DBB5C150087DDA6 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = E56DC4982DBB5C150087DDA6 /* .swiftlint.yml */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		E5B400222DC77C2900012BB0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E537715E2DB94F8E00E932D0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E53771652DB94F8E00E932D0;
+			remoteInfo = TVING_Clone;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		E5190FCD2DB957F400FE7974 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E5190FCE2DB957F400FE7974 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -68,7 +78,16 @@
 		E519102E2DBA3F2C00FE7974 /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.otf"; sourceTree = "<group>"; };
 		E53771662DB94F8E00E932D0 /* TVING_Clone.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TVING_Clone.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E56DC4982DBB5C150087DDA6 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		E5B4001E2DC77C2900012BB0 /* TVING_CloneTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TVING_CloneTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		E5B4001F2DC77C2900012BB0 /* TVING_CloneTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = TVING_CloneTests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		E53771632DB94F8E00E932D0 /* Frameworks */ = {
@@ -77,6 +96,13 @@
 			files = (
 				E5190FB72DB9572200FE7974 /* SnapKit in Frameworks */,
 				E5190FFD2DB973DF00FE7974 /* Then in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E5B4001B2DC77C2900012BB0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -210,6 +236,7 @@
 			isa = PBXGroup;
 			children = (
 				E5190FD52DB957F400FE7974 /* TVING_Clone */,
+				E5B4001F2DC77C2900012BB0 /* TVING_CloneTests */,
 				E53771672DB94F8E00E932D0 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -218,6 +245,7 @@
 			isa = PBXGroup;
 			children = (
 				E53771662DB94F8E00E932D0 /* TVING_Clone.app */,
+				E5B4001E2DC77C2900012BB0 /* TVING_CloneTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -247,6 +275,29 @@
 			productReference = E53771662DB94F8E00E932D0 /* TVING_Clone.app */;
 			productType = "com.apple.product-type.application";
 		};
+		E5B4001D2DC77C2900012BB0 /* TVING_CloneTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E5B400262DC77C2900012BB0 /* Build configuration list for PBXNativeTarget "TVING_CloneTests" */;
+			buildPhases = (
+				E5B4001A2DC77C2900012BB0 /* Sources */,
+				E5B4001B2DC77C2900012BB0 /* Frameworks */,
+				E5B4001C2DC77C2900012BB0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E5B400232DC77C2900012BB0 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				E5B4001F2DC77C2900012BB0 /* TVING_CloneTests */,
+			);
+			name = TVING_CloneTests;
+			packageProductDependencies = (
+			);
+			productName = TVING_CloneTests;
+			productReference = E5B4001E2DC77C2900012BB0 /* TVING_CloneTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -259,6 +310,10 @@
 				TargetAttributes = {
 					E53771652DB94F8E00E932D0 = {
 						CreatedOnToolsVersion = 16.3;
+					};
+					E5B4001D2DC77C2900012BB0 = {
+						CreatedOnToolsVersion = 16.3;
+						TestTargetID = E53771652DB94F8E00E932D0;
 					};
 				};
 			};
@@ -281,6 +336,7 @@
 			projectRoot = "";
 			targets = (
 				E53771652DB94F8E00E932D0 /* TVING_Clone */,
+				E5B4001D2DC77C2900012BB0 /* TVING_CloneTests */,
 			);
 		};
 /* End PBXProject section */
@@ -299,6 +355,13 @@
 				E51910252DBA3F1400FE7974 /* Pretendard-Black.otf in Resources */,
 				E5190FD72DB957F400FE7974 /* Assets.xcassets in Resources */,
 				E56DC4992DBB5C150087DDA6 /* .swiftlint.yml in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E5B4001C2DC77C2900012BB0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -352,7 +415,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E5B4001A2DC77C2900012BB0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		E5B400232DC77C2900012BB0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E53771652DB94F8E00E932D0 /* TVING_Clone */;
+			targetProxy = E5B400222DC77C2900012BB0 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		E5190FCF2DB957F400FE7974 /* LaunchScreen.storyboard */ = {
@@ -539,6 +617,40 @@
 			};
 			name = Release;
 		};
+		E5B400242DC77C2900012BB0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "Rx.TVING-CloneTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TVING_Clone.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/TVING_Clone";
+			};
+			name = Debug;
+		};
+		E5B400252DC77C2900012BB0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "Rx.TVING-CloneTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TVING_Clone.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/TVING_Clone";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -556,6 +668,15 @@
 			buildConfigurations = (
 				E537717A2DB94F9000E932D0 /* Debug */,
 				E537717B2DB94F9000E932D0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E5B400262DC77C2900012BB0 /* Build configuration list for PBXNativeTarget "TVING_CloneTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E5B400242DC77C2900012BB0 /* Debug */,
+				E5B400252DC77C2900012BB0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/TVING_Clone/TVING_CloneTests/TextFieldValidationTests.swift
+++ b/TVING_Clone/TVING_CloneTests/TextFieldValidationTests.swift
@@ -1,0 +1,129 @@
+//
+// TextFieldValidationTests.swift
+//  TVING_CloneTests
+//
+//  Created by 성현주 on 5/4/25.
+//
+
+import XCTest
+@testable import TVING_Clone
+
+final class TextFieldBooleanAssertionTests: XCTestCase {
+
+    // MARK: - 1. 기본 조건 테스트
+
+    func test_textField_isValidShouldBeFalseWhenEmptyAndRequiresNonEmpty() {
+        let textField = TextField()
+        textField.validationType = [.nonEmpty]
+
+        textField.text = ""
+        XCTAssertFalse(textField.isValid)
+    }
+
+    func test_textField_isValidShouldBeTrueWhenNonEmpty() {
+        let textField = TextField()
+        textField.validationType = [.nonEmpty]
+
+        textField.text = "content"
+        XCTAssertTrue(textField.isValid)
+    }
+
+    // MARK: - 2. minLength 단독 & 복합 조합 테스트
+
+    func test_textField_isValidShouldBeFalseWhenTooShortWithMinLength() {
+        let textField = TextField()
+        textField.validationType = [.minLength(6)]
+
+        textField.text = "12345"
+        XCTAssertFalse(textField.isValid)
+    }
+
+    func test_textField_isValidShouldBeTrueWhenMeetsMinLength() {
+        let textField = TextField()
+        textField.validationType = [.minLength(6)]
+
+        textField.text = "123456"
+        XCTAssertTrue(textField.isValid)
+    }
+
+    func test_textField_isValidShouldBeFalseWhenNonEmptyAndMinLengthButTooShort() {
+        let textField = TextField()
+        textField.validationType = [.nonEmpty, .minLength(10)]
+
+        textField.text = "short"
+        XCTAssertFalse(textField.isValid)
+    }
+
+    func test_textField_isValidShouldBeTrueWhenValidNonEmptyAndMinLength() {
+        let textField = TextField()
+        textField.validationType = [.nonEmpty, .minLength(10)]
+
+        textField.text = "longenough"
+        XCTAssertTrue(textField.isValid)
+    }
+
+    // MARK: - 3. 이메일 유효성 테스트
+
+    func test_textField_isValidShouldBeFalseForInvalidEmail() {
+        let textField = TextField()
+        textField.validationType = [.email]
+
+        textField.text = "abc.com"
+        XCTAssertFalse(textField.isValid)
+    }
+
+    func test_textField_isValidShouldBeTrueForValidEmail() {
+        let textField = TextField()
+        textField.validationType = [.email]
+
+        textField.text = "test@ssu.ac.kr"
+        XCTAssertTrue(textField.isValid)
+    }
+
+    // MARK: - 4. 한글만 허용하는 닉네임 필드 테스트
+
+    func test_textField_isValidShouldBeTrueForKoreanOnly() {
+        let textField = TextField()
+        textField.validationType = [.koreanOnly]
+
+        textField.text = "홍길동"
+        XCTAssertTrue(textField.isValid)
+    }
+
+    func test_textField_isValidShouldBeFalseWhenKoreanOnlyButIncludesEnglish() {
+        let textField = TextField()
+        textField.validationType = [.koreanOnly]
+
+        textField.text = "홍Gil동"
+        XCTAssertFalse(textField.isValid)
+    }
+
+    // MARK: - 5. 상태 변화 반응성 테스트 (textDidChange)
+
+    func test_textFieldValidityShouldChangeWhenTextChanges() {
+        let textField = TextField()
+        textField.validationType = [.nonEmpty]
+
+        class DummyDelegate: TextFieldValidatingDelegate {
+            var wasCalled = false
+            func textFieldValidityDidChange() { wasCalled = true }
+        }
+
+        let delegate = DummyDelegate()
+        textField.validationDelegate = delegate
+
+        textField.text = "new"
+        textField.sendActions(for: .editingChanged)
+
+        XCTAssertTrue(delegate.wasCalled)
+    }
+
+    // MARK: - 6. 초기 상태가 비어있는 경우
+
+    func test_textField_isValidShouldBeFalseWhenInitialTextIsNil() {
+        let textField = TextField()
+        textField.validationType = [.nonEmpty]
+
+        XCTAssertFalse(textField.isValid)
+    }
+}


### PR DESCRIPTION
## 개요

`TextField` 컴포넌트의 `validationType` 조합에 따른 유효성 검증 로직을 테스트하는 단위 테스트 파일  
`TextFieldBooleanAssertionTests.swift`를 추가했습니다.  
Boolean Assertion(`XCTAssertTrue`, `XCTAssertFalse`)을 활용하여 조건별로 `isValid` 동작을 명확히 검증할수 있도록 했습니다.



## 테스트 대상

- **TextField.swift**
  - 커스텀 `UITextField` 서브클래스
  - `.validationType` 배열에 따라 유효성 판단
  - `.isValid` 연산 프로퍼티를 통해 결과 반환
  - `editingChanged` 이벤트 시 `TextFieldValidatingDelegate` 호출



##  테스트 목적

| 테스트 항목 | 설명 |
|-------------|------|
| `nonEmpty` | 텍스트가 비어있지 않아야 통과 |
| `minLength(n)` | 지정된 길이 이상 입력 시 통과 |
| `nonEmpty + minLength` | 두 조건 모두 만족해야 통과 |
| `email` | 형식이 유효한 이메일인지 검사 |
| `koreanOnly` | 오직 한글만 입력되었는지 확인 |
| `editingChanged` | 텍스트 변경 시 델리게이트 정상 호출 확인 |
| 초기 상태 | 텍스트가 없는 초기 상태는 무조건 `false` 반환 |



## 테스트 커버리지

- `isValid` Boolean 반환값의 신뢰성 확보
- ValidationType 조합별 통합 검증
- 델리게이트 호출 여부까지 포함한 상태 반응성 검증




## 💡 추가 고려 사항

- 추후 테스트 대상이 되는 `ValidationType` 자체에 대한 단위 테스트도 분리 가능한데 우선은 텍스트필드자체의 유효성을 검증할수 있도록 했습니다.
- `TextField`를 포함한 뷰 컨트롤러 단위의 통합 테스트도 별도 커버리지로 확장할 예정입니다 
- 그냥 간단한게 boolean 어썰션을 사용해본 테스트 코드라서 커버리지는 아직 처참합니다 ㅠ 적용에 의의를 두고 확인해주시면 갑사드리겠습니다:)

---

